### PR TITLE
Chore: Client-Server JSON-RPC specification

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -16,7 +16,7 @@
 
 1. [Data Exchange Format](https://github.com/p2panda/design-document/blob/master/spec/server-client/data_exchange_format.md)
 2. [Meta Schema Definitions & Migrations](https://github.com/p2panda/design-document/blob/master/spec/server-client/meta_schema.md)
-3. [Bamboo Publish API](https://github.com/p2panda/design-document/blob/master/spec/server-client/bamboo_publish_api.md)
+3. [RPC API](https://github.com/p2panda/design-document/blob/master/spec/server-client/rpc.md)
 4. [Message Schema Specification](https://github.com/p2panda/design-document/blob/master/spec/server-client/msg_schema.md)
 5. [Security & Encryption](https://github.com/p2panda/design-document/blob/master/spec/server-client/encryption.md)
 

--- a/spec/server-client/bamboo_publish_api.md
+++ b/spec/server-client/bamboo_publish_api.md
@@ -1,3 +1,0 @@
-# Bamboo entry creation protocol "Publish API"
-
-- How to get the next bamboo entry arguments and how to create a new entry on the server?

--- a/spec/server-client/rpc.md
+++ b/spec/server-client/rpc.md
@@ -41,19 +41,9 @@ JSON-RPC via WebSocket or HTTP.
 
 * Array of the requested instance data (`@TODO`)
 
-## Status & Fork Proofs
+## Server schemas
 
-### panda_about
-
-**Parameters:**
-
-* %
-
-**Returns:**
-
-`@TODO`. Basic data like server version etc.
-
-##### panda_schemas
+### panda_getSchemas
 
 **Parameters:**
 
@@ -71,14 +61,4 @@ JSON-RPC via WebSocket or HTTP.
 
 **Returns:**
 
-`@TODO: Write more about fork proofs`. Array of fork proofs (identified forked logs), the regarding positions in the logs where the forks occured and the current vote status which fork to follow.
-
-### panda_voteFork
-
-**Parameters:**
-
-* `@TODO`
-
-**Returns:**
-
-* %
+* `@TODO: Write more about fork proofs`. Array of fork proofs (identified forked logs), the regarding positions in the logs where the forks occured and the current vote status which fork to follow. Users can vote on forks by publishing special system messages.

--- a/spec/server-client/rpc.md
+++ b/spec/server-client/rpc.md
@@ -4,7 +4,7 @@ JSON-RPC via WebSocket or HTTP.
 
 ## Publishing
 
-##### panda_getNextEntryArguments
+### panda_getNextEntryArguments
 
 **Parameters:**
 
@@ -17,7 +17,7 @@ JSON-RPC via WebSocket or HTTP.
 * `encodedEntrySkiplink`
 * `lastSeqNum`
 
-##### panda_publishEntry
+### panda_publishEntry
 
 **Parameters:**
 
@@ -30,7 +30,7 @@ JSON-RPC via WebSocket or HTTP.
 
 ## Reading
 
-##### panda_getInstances
+### panda_getInstances
 
 **Parameters:**
 
@@ -43,7 +43,7 @@ JSON-RPC via WebSocket or HTTP.
 
 ## Status & Fork Proofs
 
-##### panda_about
+### panda_about
 
 **Parameters:**
 
@@ -63,7 +63,7 @@ JSON-RPC via WebSocket or HTTP.
 
 `@TODO`. Array of registered data schemas on this server.
 
-##### panda_getForkProofs
+### panda_getForkProofs
 
 **Parameters:**
 
@@ -73,7 +73,7 @@ JSON-RPC via WebSocket or HTTP.
 
 `@TODO: Write more about fork proofs`. Array of fork proofs (identified forked logs), the regarding positions in the logs where the forks occured and the current vote status which fork to follow.
 
-##### panda_voteFork
+### panda_voteFork
 
 **Parameters:**
 

--- a/spec/server-client/rpc.md
+++ b/spec/server-client/rpc.md
@@ -1,0 +1,84 @@
+# RPC API
+
+JSON-RPC via WebSocket or HTTP.
+
+## Publishing
+
+##### panda_getNextEntryArguments
+
+**Parameters:**
+
+1. `author` (hex encoded ed25519 public key bytes) `String`
+2. `logId` `Number`
+
+**Returns:**
+
+* `encodedEntryBacklink`
+* `encodedEntrySkiplink`
+* `lastSeqNum`
+
+##### panda_publishEntry
+
+**Parameters:**
+
+1. `encodedEntry` Encoded bamboo entry (hex encoded bytes) `String`
+2. `encodedPayload` Encoded CBOR payload (hex encoded bytes) `String`
+
+**Returns:**
+
+* %
+
+## Reading
+
+##### panda_getInstances
+
+**Parameters:**
+
+1. `schema` Name of the schema `String`
+2. `filter` `Object` (`@TODO`)
+
+**Returns:**
+
+* Array of the requested instance data (`@TODO`)
+
+## Status & Fork Proofs
+
+##### panda_about
+
+**Parameters:**
+
+* %
+
+**Returns:**
+
+`@TODO`. Basic data like server version etc.
+
+##### panda_schemas
+
+**Parameters:**
+
+* %
+
+**Returns:**
+
+`@TODO`. Array of registered data schemas on this server.
+
+##### panda_getForkProofs
+
+**Parameters:**
+
+* %
+
+**Returns:**
+
+`@TODO: Write more about fork proofs`. Array of fork proofs (identified forked logs), the regarding positions in the logs where the forks occured and the current vote status which fork to follow.
+
+##### panda_voteFork
+
+**Parameters:**
+
+* `@TODO`
+
+**Returns:**
+
+* %

--- a/spec/server-client/rpc.md
+++ b/spec/server-client/rpc.md
@@ -53,6 +53,8 @@ JSON-RPC via WebSocket or HTTP.
 
 `@TODO`. Array of registered data schemas on this server.
 
+## Fork proofs (idea)
+
 ### panda_getForkProofs
 
 **Parameters:**


### PR DESCRIPTION
The idea is use an `JSON-RPC` API between Client - Server via WebSocket (optional HTTP) for all sorts of communication (publishing, reading materialized data from the server, system data like currently registered schemas and fork proofs etc.). We use JSON-RPC here as its client-facing and readable / easier to debug when developing in the browser. Please note: The bamboo entry payloads are still encoded as CBOR as this is data which is used in other parts of the protocol as well (server-server)